### PR TITLE
ci: add commitsar conventional commit linter

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,16 @@
+name: Commits
+
+on:
+  pull_request:
+
+jobs:
+  commitsar:
+    name: Conventional commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: aevea/commitsar@v0.20.2
+


### PR DESCRIPTION
Adds [commitsar](https://github.com/aevea/commitsar) to enforce Conventional Commits on all PRs.