### PR TITLE
fix: add CONFIG_FROM_ENV to Docker Compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ services:
     ports:
       - "9234:9234"
     environment:
+      CONFIG_FROM_ENV: "true"
       MOSQUITTO_BROKER_ENDPOINT: tcp://mosquitto:1883
       MOSQUITTO_USERNAME: ""
       MOSQUITTO_PASSWORD: ""


### PR DESCRIPTION
Fixes #127 — the Docker Compose example was missing `CONFIG_FROM_ENV: "true"`, causing the container to fail looking for `config.yaml` even when all settings were provided via environment variables. The `docker run` example already had `--config-from-env` so this brings Compose into line.